### PR TITLE
extend syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export default function swaggerMiddleware(opts) {
     .then(
       result => {
         client = result;
-        console.log('swaggerMiddleware:inited', result, client);
+        //console.log('swaggerMiddleware:inited', result, client);
 
         while (waitQueue.length) {
           const a = waitQueue.shift();
@@ -28,7 +28,7 @@ export default function swaggerMiddleware(opts) {
     const { swagger, types, ...rest } = action;
     const [REQUEST, SUCCESS, FAILURE] = types;
     const callApi = (c, sw) => {
-      console.log('swaggerMiddleware:callApi', c, sw, action);
+      // console.log('swaggerMiddleware:callApi', c, sw, action);
       return typeof sw === 'function'
         ? sw(c)
           .then(
@@ -40,7 +40,7 @@ export default function swaggerMiddleware(opts) {
           })
         : console.error('Swagger api call is not a function')
     };
-    console.log('swaggerMiddleware: got it!', client, waitQueue);
+    // console.log('swaggerMiddleware: got it!', client, waitQueue);
 
     // Add async api calls to queue if not ready
     if (!client) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import Swagger from 'swagger-client';
 
 export default (opts) => () => next => action => {
-  const { swagger, types, ...rest } = action; // eslint-disable-line no-redeclare
+  const { swagger, types, ...rest } = action;
   const [REQUEST, SUCCESS, FAILURE] = types;
   const waitQueue = [];
   let ready = false;
@@ -38,7 +38,7 @@ export default (opts) => () => next => action => {
     } else {
       // Call payload and pass the swagger client
       callApi(client)(action.swagger);
-      return next(action);
+      return next({ ...rest, type: REQUEST });
     }
   } else {
     return next(action);

--- a/src/index.js
+++ b/src/index.js
@@ -1,38 +1,47 @@
-import Swagger from 'swagger-client'
+import Swagger from 'swagger-client';
 
-export default (opts) => store => next => {
-  var waitQueue = []
-  var ready = false
-
-  var callApi = (swagger) => {
-    if (typeof swagger === 'function')
-      swagger(client)
-    else
-      console.error("Swagger api call is not a function")
-  }
-
-  var client = new Swagger({
+export default (opts) => () => next => action => {
+  const { swagger, types, ...rest } = action; // eslint-disable-line no-redeclare
+  const [REQUEST, SUCCESS, FAILURE] = types;
+  const waitQueue = [];
+  let ready = false;
+  const callApi = client => sw => {
+    if (typeof swagger === 'function') {
+      sw(client)
+        .then(
+          (result) => next({ ...rest, result, type: SUCCESS }),
+          (error) => next({ ...rest, error, type: FAILURE })
+        ).catch(error => {
+          console && console.error && console.error('MIDDLEWARE ERROR:', error);
+          next({ ...rest, error, type: FAILURE });
+        });
+    } else {
+      console.error('Swagger api call is not a function');
+    }
+  };
+  const client = new Swagger({
     ...opts,
     success: () => {
       ready = true
       while (waitQueue.length) {
-        var action = waitQueue.shift()
-        callApi(action.swagger)
-        next(action)
+        const a = waitQueue.shift();
+        callApi(client)(a.swagger);
+        next({ ...rest, type: REQUEST });
       }
     }
   });
-  return action => {
-    if (action.swagger) {
-      // Add async api calls to queue if not ready
-      if (ready == false)
-        waitQueue.push(action)
-      else {
-        // Call payload and pass the swagger client
-        callApi(action.swagger)
-        return next(action)
-      }
-    } else 
-      return next(action)
+
+  if (action.swagger) {
+    // Add async api calls to queue if not ready
+    if (!ready) {
+      waitQueue.push(action);
+    } else {
+      // Call payload and pass the swagger client
+      callApi(client)(action.swagger);
+      return next(action);
+    }
+  } else {
+    return next(action);
   }
+  return false;
 }


### PR DESCRIPTION
I think a little bit better change syntax of actions to:
```
function fetchPet() {
  return { 
    types: ["FETCH_PETS", "FETCH_PETS_SUCCESS", "FETCH_PETS_FAILED"],
    swagger: api => api.pet.findPetsByStatus({status: 'available'})
  }
}
```

does not check it yet.